### PR TITLE
Modify the installation instruction to use the package name instead of the GitHub endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Quickstart
 
 ```
-bower install zurb/foundation-icon-fonts
+bower install foundation-icon-fonts
 ```


### PR DESCRIPTION
As mentioned in issue #3 I've registered the package on Bower registry and this is the modified version of the installation command.