### PR TITLE
Fix missing "ignore" entry in bower.json' warning.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "foundation-icon-fonts",
   "version": "3.0.0",
-  "main": ["foundation-icons.css"]
+  "main": ["foundation-icons.css"],
+  "ignore": []
 }


### PR DESCRIPTION
When I installed this package by adding it as a dependency, bower complains
that the bower.json file is missing a required field.

This pull request adds an empty array of path to be ignored in order to make bower happy.
