### PR TITLE
Currently, icons in Firefox on Mac are rendered thicker than they are…

### DIFF
--- a/_foundation-icons.scss
+++ b/_foundation-icons.scss
@@ -309,6 +309,7 @@
   -webkit-font-smoothing: antialiased;
   display: inline-block;
   text-decoration: inherit;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .fi-address-book:before { content: "\f100"; }


### PR DESCRIPTION
… supposed to. This unfortunately vendor specific rule fixes it.
