### PR TITLE
Added package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
     "url": "https://github.com/zurb/foundation-icon-fonts"
   },
   "author": "Various YetiNauts at Zurb",
-  "ignore": []
+  "ignore": [],
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "foundation-icon-fonts",
+  "version": "3.0.0",
+  "description": "Zurb Foundation Icon Fonts",
+  "main": ["foundation-icons.css"],
+  "keywords" : [
+    "zurb",
+    "foundation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zurb/foundation-icon-fonts"
+  },
+  "author": "Various YetiNauts at Zurb",
+  "ignore": []
+}


### PR DESCRIPTION
Allows yarn to work properly when fetching a tarball from github.

Should allow for easy addition to the NPM registry.

There is a TODO of adding a license type to package.json.